### PR TITLE
Update dependencies to fix "npm audit"

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -28,13 +28,13 @@ let categories = [
   },
   {
     name: 'Längster Bahnsteig',
-    find: station => _(station.platforms).map('length').max(),
+    find: station => _(station.platforms).map('length').max() || 0,
     format: n => n.toFixed(2).replace('.', ',') + ' m',
     reverse: true,
   },
   {
     name: 'Höchster Bahnsteig',
-    find: station => _(station.platforms).map('height').max(),
+    find: station => _(station.platforms).map('height').max() || 0,
     format: n => n.toFixed(2).replace('.', ',') + ' m',
     reverse: true,
   },
@@ -51,7 +51,7 @@ let categories = [
     name: 'Ältester Aufzug',
     find: n => _(n.elevators).map(e => +e.year).filter().min(),
     filter: n => n.elevators.length,
-    format: n => n === Infinity ? '—' : n,
+    format: n => (n === Infinity || n === undefined) ? '—' : n,
   },
   {
     name: 'Größte Aufzugskabine',
@@ -93,10 +93,6 @@ while (cards.size < potentialCards.length * 4) {
   let card = potentialCards[group].shift();
   cards.add(card);
 }
-
-let jannowitz = _.findWhere(stations, { name: 'Jannowitzbrücke' });
-cards.add(jannowitz);
-cards.delete(_.findWhere(stations, { name: 'Anwanden' }));
 
 cards = _(Array.from(cards)).sortBy(s => s.state).value();
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.0",
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.22.0",
     "image-size": "^0.4.0",
     "js-yaml": "^3.4.6",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.15",
     "pdfkit": "^0.7.1",
     "request": "^2.67.0",
     "slug": "^0.9.1"


### PR DESCRIPTION
I just tried to re-run the script in today's node versions, so here's the PR to update the required dependencies :)

Note that `_.findWhere()` was removed from *lodash* in v4. I simply deleted the whole block regarding the stations *Jannowitzbrücke* and *Anwanden*, as it was probably just added as part of the DB Hackathon (:wave: @dbopendata). With lodash v4, the default sorting has changed, so *Anwanden* is no longer part of the `cards`.